### PR TITLE
feat: add SDPA attention backend with pad-once optimization

### DIFF
--- a/assembly/models/denoiser/modules/attention.py
+++ b/assembly/models/denoiser/modules/attention.py
@@ -153,90 +153,6 @@ class EncoderLayer(nn.Module):
         # 2. global attention
         norm_hidden_states = self.norm2(hidden_states, timestep, batch)
 
-        # attn_bias = graph_mask  # (B, global_attn_max_seqlen, global_attn_max_seqlen)
-        # # Ensure attention_bias is a slice multiple of 8
-        # nearest_8_multiple = ((global_attn_max_seqlen + 7) // 8) * 8
-        # attn_bias_padded = torch.zeros(
-        #     (attn_bias.shape[0], nearest_8_multiple, nearest_8_multiple),
-        #     device=attn_bias.device,
-        # ).half()
-        # attn_bias_padded[:, :global_attn_max_seqlen, :global_attn_max_seqlen] = (
-        #     attn_bias
-        # )
-        # attn_bias_padded = attn_bias_padded.unsqueeze(1).expand(
-        #     -1, self.num_attention_heads, -1, -1
-        # )
-
-        # global_qkv = (
-        #     self.global_attn_to_qkv(norm_hidden_states)
-        #     .reshape(n_points, 3, self.num_attention_heads * self.attention_head_dim)
-        #     .unbind(1)
-        # )  # tuple of 3 tensors: (n_points, num_heads, head_dim)
-        # q_padded, global_valid_mask = self.pad_sequence(
-        #     global_qkv[0], global_attn_seqlens, global_attn_max_seqlen
-        # )
-        # k_padded, _ = self.pad_sequence(
-        #     global_qkv[1], global_attn_seqlens, global_attn_max_seqlen
-        # )
-        # v_padded, _ = self.pad_sequence(
-        #     global_qkv[2], global_attn_seqlens, global_attn_max_seqlen
-        # )
-
-        # global_out = xformers.ops.memory_efficient_attention(
-        # query=q_padded.view(
-        #     -1,
-        #     global_attn_max_seqlen,
-        #     self.num_attention_heads,
-        #     self.attention_head_dim,
-        # ),
-        # key=k_padded.view(
-        #     -1,
-        #     global_attn_max_seqlen,
-        #     self.num_attention_heads,
-        #     self.attention_head_dim,
-        # ),
-        # value=v_padded.view(
-        #     -1,
-        #     global_attn_max_seqlen,
-        #     self.num_attention_heads,
-        #     self.attention_head_dim,
-        # ),
-        #     attn_bias=attn_bias_padded[
-        #         :, :, :global_attn_max_seqlen, :global_attn_max_seqlen
-        #     ],
-        # )  # (B, max_seqlen, num_heads, head_dim)
-
-        # global_out = torch.nn.functional.scaled_dot_product_attention(
-        #     query=q_padded.view(
-        #         -1,
-        #         global_attn_max_seqlen,
-        #         self.num_attention_heads,
-        #         self.attention_head_dim,
-        #     ).permute(0, 2, 1, 3),
-        #     key=k_padded.view(
-        #         -1,
-        #         global_attn_max_seqlen,
-        #         self.num_attention_heads,
-        #         self.attention_head_dim,
-        #     ).permute(0, 2, 1, 3),
-        #     value=v_padded.view(
-        #         -1,
-        #         global_attn_max_seqlen,
-        #         self.num_attention_heads,
-        #         self.attention_head_dim,
-        #     ).permute(0, 2, 1, 3),
-        #     attn_mask=attn_bias_padded[
-        #         :, :, :global_attn_max_seqlen, :global_attn_max_seqlen
-        #     ],
-        # ).permute(0, 2, 1, 3)
-        # global_out = global_out.view(
-        #     -1, global_attn_max_seqlen, embed_dim
-        # )  # (B, max_seqlen, embed_dim)
-        # # unpad global_out
-        # global_out = global_out[global_valid_mask]
-        # global_out = self.global_attn_to_out(global_out)
-        # hidden_states = hidden_states + global_out
-
         global_out_flash = flash_attn.flash_attn_varlen_qkvpacked_func(
             qkv=self.global_attn_to_qkv(norm_hidden_states).reshape(
                 n_points, 3, self.num_attention_heads, self.attention_head_dim
@@ -254,3 +170,58 @@ class EncoderLayer(nn.Module):
         hidden_states = ff_output + hidden_states
 
         return hidden_states  # (n_points, embed_dim)
+
+    def forward_sdpa(
+        self,
+        hidden_states: torch.Tensor,    # (B, S, D) pre-padded
+        timestep: torch.Tensor,         # (valid_P,)
+        batch: torch.Tensor,            # (B, S) padded part indices
+        self_attn_mask: torch.Tensor,   # (B, 1, S, S) bool mask
+        global_attn_mask: torch.Tensor, # (B, 1, S, S) bool mask
+        coarse_seg_pred: Optional[torch.Tensor] = None,  # (B, S) padded, or None
+    ):
+        B, S, D = hidden_states.shape
+
+        # 1. self attention
+        norm_hidden_states = self.norm1(hidden_states, timestep, batch)
+
+        qkv = self.self_attn_to_qkv(norm_hidden_states).reshape(
+            B, S, 3, self.num_attention_heads, self.attention_head_dim
+        )
+        q, k, v = qkv.unbind(dim=2)  # each (B, S, H, Dh)
+        q, k, v = q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2)
+
+        attn_output = torch.nn.functional.scaled_dot_product_attention(
+            q, k, v, attn_mask=self_attn_mask
+        )  # (B, H, S, Dh)
+        attn_output = attn_output.transpose(1, 2).reshape(B, S, D)
+
+        attn_output = self.self_attn_to_out(attn_output)
+        hidden_states = hidden_states + attn_output
+
+        if coarse_seg_pred is not None:
+            hidden_states = hidden_states * (1 + coarse_seg_pred.unsqueeze(-1))
+
+        # 2. global attention
+        norm_hidden_states = self.norm2(hidden_states, timestep, batch)
+
+        qkv = self.global_attn_to_qkv(norm_hidden_states).reshape(
+            B, S, 3, self.num_attention_heads, self.attention_head_dim
+        )
+        q, k, v = qkv.unbind(dim=2)
+        q, k, v = q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2)
+
+        global_out = torch.nn.functional.scaled_dot_product_attention(
+            q, k, v, attn_mask=global_attn_mask
+        )
+        global_out = global_out.transpose(1, 2).reshape(B, S, D)
+
+        global_out = self.global_attn_to_out(global_out)
+        hidden_states = hidden_states + global_out
+
+        # 3. feed forward
+        norm_hidden_states = self.norm3(hidden_states)
+        ff_output = self.ff(norm_hidden_states)
+        hidden_states = ff_output + hidden_states
+
+        return hidden_states  # (B, S, D)

--- a/assembly/models/denoiser/modules/denoiser_transformer.py
+++ b/assembly/models/denoiser/modules/denoiser_transformer.py
@@ -25,6 +25,7 @@ class DenoiserTransformer(nn.Module):
         dropout_rate: float,
         trans_out_dim: int,
         rot_out_dim: int,
+        use_flash_attn: bool = True,
     ):
         super().__init__()
 
@@ -36,7 +37,7 @@ class DenoiserTransformer(nn.Module):
         self.dropout_rate = dropout_rate
         self.trans_out_dim = trans_out_dim
         self.rot_out_dim = rot_out_dim
-
+        self.use_flash_attn = use_flash_attn
         self.ref_part_emb = nn.Embedding(2, self.embed_dim)
         self.activation = nn.SiLU()
 
@@ -310,6 +311,8 @@ class DenoiserTransformer(nn.Module):
         scale,  # (valid_P, 1)
         ref_part,  # (valid_P,)
     ):
+        if not self.use_flash_attn:
+            return self.forward_sdpa(x, timesteps, latent, part_valids, scale, ref_part)
 
         # (valid_P, embed_dim), (n_points, embed_dim)
         x_emb, shape_emb = self._gen_cond(x, latent, scale)
@@ -320,11 +323,6 @@ class DenoiserTransformer(nn.Module):
 
         # (n_points, embed_dim)
         data_emb = x_emb + shape_emb
-        # data_emb = self.pos_encoding(
-        #     x=data_emb,
-        #     part_valids=part_valids,
-        #     batch=latent["batch"],
-        # )
 
         # self_mask, gen_mask = self._gen_mask(B, N, L, part_valids)
         self_attn_seqlen = torch.bincount(latent["batch"])  # (valid_P,)
@@ -340,12 +338,6 @@ class DenoiserTransformer(nn.Module):
         global_attn_cu_seqlens = nn.functional.pad(
             torch.cumsum(global_attn_seqlen, 0), (1, 0)
         ).to(torch.int32)
-
-        # graph_mask, valid_mask = self.calc_graph_mask(
-        #     graph=graph,
-        #     points_per_part=points_per_part,
-        #     max_seq_len=global_attn_max_seqlen,
-        # )
 
         for i, layer in enumerate(self.transformer_layers):
             data_emb = layer(
@@ -369,9 +361,90 @@ class DenoiserTransformer(nn.Module):
 
         # data_emb (B, N*L, C)
         out_trans_rots = self._out(data_emb)
-        # out_graph = self._out_graph(data_emb, part_valids)
 
         return {
             "pred": out_trans_rots,  # (valid_P, 7)
-            "graph_pred": None,  # out_graph,
+            "graph_pred": None,
+        }
+
+    def forward_sdpa(
+        self,
+        x,  # (valid_P, 7)
+        timesteps,  # (valid_P,)
+        latent,  # PointTransformer Point instance
+        part_valids,  # (B, P)
+        scale,  # (valid_P, 1)
+        ref_part,  # (valid_P,)
+    ):
+        # (valid_P, embed_dim), (n_points, embed_dim)
+        x_emb, shape_emb = self._gen_cond(x, latent, scale)
+        x_emb = self._add_ref_part_emb(x_emb, ref_part)
+        x_emb = x_emb[latent["batch"]]
+        data_emb = x_emb + shape_emb  # (n_points, embed_dim)
+
+        batch_idx = latent["batch"]  # (n_points,) flat part index
+        device = data_emb.device
+
+        # --- sequence lengths ---
+        self_attn_seqlen = torch.bincount(batch_idx)  # (valid_P,)
+        self_attn_cu_seqlens = nn.functional.pad(
+            torch.cumsum(self_attn_seqlen, 0), (1, 0)
+        ).to(torch.int32)
+
+        points_per_part = torch.zeros_like(part_valids, dtype=self_attn_seqlen.dtype)
+        points_per_part[part_valids] = self_attn_seqlen
+        global_attn_seqlen = points_per_part.sum(1)  # (B,)
+        global_max_seqlen = global_attn_seqlen.max().item()
+        B = part_valids.shape[0]
+
+        # --- pad once: (n_points, D) -> (B, S, D) ---
+        seq_ranges = torch.arange(global_max_seqlen, device=device).unsqueeze(0).expand(B, -1)
+        valid_mask = seq_ranges < global_attn_seqlen.unsqueeze(1)  # (B, S)
+
+        padded_data = torch.zeros(
+            (B, global_max_seqlen, self.embed_dim), device=device, dtype=data_emb.dtype
+        )
+        padded_data[valid_mask] = data_emb
+
+        # pad batch (part indices) — fill 0 for padding (safe: masked out in attention)
+        padded_batch = torch.zeros(
+            (B, global_max_seqlen), device=device, dtype=torch.long
+        )
+        padded_batch[valid_mask] = batch_idx
+
+        # --- build masks (once, reused by all layers) ---
+        # self-attention: block-diagonal per part (same part index -> attend)
+        # part indices are globally unique, so equality correctly groups same-part points
+        self_attn_mask = (padded_batch.unsqueeze(2) == padded_batch.unsqueeze(1))  # (B, S, S)
+        self_attn_mask = self_attn_mask & valid_mask.unsqueeze(1) & valid_mask.unsqueeze(2)
+        self_attn_mask = self_attn_mask.unsqueeze(1)  # (B, 1, S, S) broadcast over heads
+
+        # global attention: all valid positions in same batch item attend to each other
+        global_attn_mask = (valid_mask.unsqueeze(1) & valid_mask.unsqueeze(2)).unsqueeze(1)
+
+        # --- transformer loop (all in padded format) ---
+        for layer in self.transformer_layers:
+            padded_data = layer.forward_sdpa(
+                hidden_states=padded_data,
+                timestep=timesteps,
+                batch=padded_batch,
+                self_attn_mask=self_attn_mask,
+                global_attn_mask=global_attn_mask,
+            )
+
+        # --- unpad once: (B, S, D) -> (n_points, D) ---
+        data_emb = padded_data[valid_mask]
+
+        # scatter to each part (mean pool)
+        data_emb = torch_scatter.segment_csr(
+            data_emb,
+            self_attn_cu_seqlens.long(),
+            reduce="mean",
+        )  # (valid_P, embed_dim)
+
+        out_trans_rots = self._out(data_emb)
+
+        return {
+            "pred": out_trans_rots,  # (valid_P, 7)
+            "graph_pred": None,
         }

--- a/configs/model/denoiser_flow_matching.yaml
+++ b/configs/model/denoiser_flow_matching.yaml
@@ -13,6 +13,7 @@ denoiser:
   dropout_rate: 0.2
   trans_out_dim: 3
   rot_out_dim: 3
+  use_flash_attn: False
 noise_scheduler:
   _target_: assembly.models.denoiser.SE3FlowMatchEulerDiscreteScheduler
   num_train_timesteps: 1000


### PR DESCRIPTION
Replace per-layer pad/unpad with single pad before transformer loop and single unpad after, using pre-computed block-diagonal self-attention mask and global attention mask. Controlled via `use_flash_attn` flag.